### PR TITLE
Mh addrf: more comprehensive RF OOK send and receive

### DIFF
--- a/src/IRTimer.cpp.h
+++ b/src/IRTimer.cpp.h
@@ -724,16 +724,28 @@ void irmp_timer_ISR(void)
             // output is active low
             digitalWriteFast(IRSND_OUTPUT_PIN, IR_OUTPUT_ACTIVE_LEVEL); // output is active low
 #  else
+#    if defined(IRSND_RF_OUTPUT)
+            if(irsnd_rf == 1) 
+            {
+              digitalWriteFast(IRSND_RF_PIN, IR_OUTPUT_ACTIVE_LEVEL);
+            }
+            else
+#    endif
             if(sDivider & 0x01) // true / inactive if sDivider is 3 or 1, so we start with active and end with inactive
             {
                 digitalWriteFast(IRSND_OUTPUT_PIN, IR_OUTPUT_INACTIVE_LEVEL);
             } else {
                 digitalWriteFast(IRSND_OUTPUT_PIN, IR_OUTPUT_ACTIVE_LEVEL);
             }
-
-
 #  endif // defined(IRSND_GENERATE_NO_SEND_RF)
         } else {
+#  if defined(IRSND_RF_OUTPUT)
+            if(irsnd_rf == 1) 
+            {
+              digitalWriteFast(IRSND_RF_PIN, IR_OUTPUT_INACTIVE_LEVEL);
+            }
+            else
+#  endif
             // irsnd off here
             digitalWriteFast(IRSND_OUTPUT_PIN, IR_OUTPUT_INACTIVE_LEVEL);
         }

--- a/src/irmp.c.h
+++ b/src/irmp.c.h
@@ -662,6 +662,21 @@
 #define RF_HME_0_PAUSE_LEN_MIN                  ((uint_fast8_t)(F_INTERRUPTS * RF_HME_0_PAUSE_TIME * MIN_TOLERANCE_20 + 0.5) - 1)
 #define RF_HME_0_PAUSE_LEN_MAX                  ((uint_fast8_t)(F_INTERRUPTS * RF_HME_0_PAUSE_TIME * MAX_TOLERANCE_20 + 0.5) + 1)
 
+#define RF_AC104_START_BIT_PULSE_LEN_MIN          ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_START_BIT_PULSE_TIME * MIN_TOLERANCE_10 + 0.5) - 1)
+#define RF_AC104_START_BIT_PULSE_LEN_MAX          ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_START_BIT_PULSE_TIME * MAX_TOLERANCE_10 + 0.5) + 1)
+#define RF_AC104_START_BIT_PAUSE_LEN_MIN          ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_START_BIT_PAUSE_TIME * MIN_TOLERANCE_10 + 0.5) - 1)
+#define RF_AC104_START_BIT_PAUSE_LEN_MAX          ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_START_BIT_PAUSE_TIME * MAX_TOLERANCE_10 + 0.5) + 1)
+#define RF_AC104_1_PAUSE_LEN_EXACT                ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_1_PAUSE_TIME + 0.5))
+#define RF_AC104_1_PULSE_LEN_MIN                  ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_1_PULSE_TIME * MIN_TOLERANCE_20 + 0.5) - 1)
+#define RF_AC104_1_PULSE_LEN_MAX                  ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_1_PULSE_TIME * MAX_TOLERANCE_20 + 0.5) + 1)
+#define RF_AC104_1_PAUSE_LEN_MIN                  ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_1_PAUSE_TIME * MIN_TOLERANCE_20 + 0.5) - 1)
+#define RF_AC104_1_PAUSE_LEN_MAX                  ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_1_PAUSE_TIME * MAX_TOLERANCE_20 + 0.5) + 1)
+#define RF_AC104_0_PAUSE_LEN                      ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_0_PAUSE_TIME))
+#define RF_AC104_0_PULSE_LEN_MIN                  ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_0_PULSE_TIME * MIN_TOLERANCE_20 + 0.5) - 1)
+#define RF_AC104_0_PULSE_LEN_MAX                  ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_0_PULSE_TIME * MAX_TOLERANCE_20 + 0.5) + 1)
+#define RF_AC104_0_PAUSE_LEN_MIN                  ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_0_PAUSE_TIME * MIN_TOLERANCE_20 + 0.5) - 1)
+#define RF_AC104_0_PAUSE_LEN_MAX                  ((uint_fast8_t)(F_INTERRUPTS * RF_AC104_0_PAUSE_TIME * MAX_TOLERANCE_20 + 0.5) + 1)
+
 
 #define AUTO_FRAME_REPETITION_LEN               (uint_fast16_t)(F_INTERRUPTS * AUTO_FRAME_REPETITION_TIME + 0.5)
 // use uint_fast16_t!
@@ -2320,6 +2335,33 @@ static const PROGMEM IRMP_PARAMETER rf_hme_param =
 
 #endif
 
+#if IRMP_SUPPORT_RF_AC104_PROTOCOL == 1
+
+static const PROGMEM IRMP_PARAMETER rf_ac104_param =
+{
+    RF_AC104_PROTOCOL,                                                    // protocol:        ir protocol
+
+    RF_AC104_1_PULSE_LEN_MIN,                                             // pulse_1_len_min: minimum length of pulse with bit value 1
+    RF_AC104_1_PULSE_LEN_MAX,                                             // pulse_1_len_max: maximum length of pulse with bit value 1
+    RF_AC104_1_PAUSE_LEN_MIN,                                             // pause_1_len_min: minimum length of pause with bit value 1
+    RF_AC104_1_PAUSE_LEN_MAX,                                             // pause_1_len_max: maximum length of pause with bit value 1
+    RF_AC104_0_PULSE_LEN_MIN,                                             // pulse_0_len_min: minimum length of pulse with bit value 0
+    RF_AC104_0_PULSE_LEN_MAX,                                             // pulse_0_len_max: maximum length of pulse with bit value 0
+    RF_AC104_0_PAUSE_LEN_MIN,                                             // pause_0_len_min: minimum length of pause with bit value 0
+    RF_AC104_0_PAUSE_LEN_MAX,                                             // pause_0_len_max: maximum length of pause with bit value 0
+    RF_AC104_ADDRESS_OFFSET,                                              // address_offset:  address offset
+    RF_AC104_ADDRESS_OFFSET + RF_AC104_ADDRESS_LEN,                         // address_end:     end of address
+    RF_AC104_COMMAND_OFFSET,                                              // command_offset:  command offset
+    RF_AC104_COMMAND_OFFSET + RF_AC104_COMMAND_LEN,                         // command_end:     end of command
+    RF_AC104_COMPLETE_DATA_LEN,                                           // complete_len:    complete length of frame
+    RF_AC104_STOP_BIT,                                                    // stop_bit:        flag: frame has stop bit
+    RF_AC104_LSB,                                                         // lsb_first:       flag: LSB first
+    RF_AC104_FLAGS                                                        // flags:           some flags
+};
+
+
+#endif
+
 
 static uint_fast8_t                             irmp_bit;               // current bit position
 static IRMP_PARAMETER                           irmp_param;
@@ -2736,6 +2778,16 @@ static uint_fast32_t irmp_tmp_command;                                      // i
 static uint_fast16_t irmp_tmp_command;                                      // ir command
 #endif
 
+#if IRMP_SUPPORT_RF_AC104_PROTOCOL == 1
+static uint_fast8_t ac104_preamble; //A3
+static uint_fast32_t ac104_remote_id; // 24 bit id
+static uint_fast8_t ac104_parity;
+#ifndef RF_AC104_IDCHECK
+#define RF_AC104_IDCHECK  0x4647a8
+#endif
+#endif // IRMP_SUPPORT_RF_AC104_PROTOCOL
+
+
 #if (IRMP_SUPPORT_RC5_PROTOCOL == 1 && (IRMP_SUPPORT_FDC_PROTOCOL == 1 || IRMP_SUPPORT_RCCAR_PROTOCOL == 1)) || IRMP_SUPPORT_NEC42_PROTOCOL == 1
 static uint_fast16_t irmp_tmp_address2;                                     // ir address
 static uint_fast16_t irmp_tmp_command2;                                     // ir command
@@ -2786,6 +2838,30 @@ irmp_store_bit (uint_fast8_t value)
       hme_manchester_store = 2; // reset
     }
     else
+#endif
+
+#if IRMP_SUPPORT_RF_AC104_PROTOCOL == 1
+    if(irmp_bit == 0) 
+    {
+      ac104_preamble = value;
+      ac104_remote_id = 0;
+      ac104_parity = 0;
+    } 
+    else if (irmp_bit < 8) 
+    {
+      ac104_preamble <<= 1;
+      ac104_preamble |= value;
+    } 
+    else if (irmp_bit < irmp_param.address_offset) 
+    {
+      ac104_remote_id <<= 1;
+      ac104_remote_id |= value;
+    } 
+    else if (irmp_bit >= irmp_param.command_end && irmp_bit < 64) 
+    {
+      ac104_parity <<=1;
+      ac104_parity |= value;
+    } // else store in address and command, last bit is one, but we have enought checks
 #endif
 
 #if IRMP_SUPPORT_ACP24_PROTOCOL == 1
@@ -3569,6 +3645,23 @@ uint_fast8_t irmp_ISR(void)
                     }
                     else
 #endif // IRMP_SUPPORT_RF_HME_PROTOCOL == 1
+
+#if IRMP_SUPPORT_RF_AC104_PROTOCOL == 1
+                    if (irmp_pulse_time >= RF_AC104_START_BIT_PULSE_LEN_MIN && irmp_pulse_time <= RF_AC104_START_BIT_PULSE_LEN_MAX &&
+                        irmp_pause_time >= RF_AC104_START_BIT_PAUSE_LEN_MIN && irmp_pause_time <= RF_AC104_START_BIT_PAUSE_LEN_MAX)
+                    {
+                        ANALYZE_PRINTF5 ("protocol = RF_AC104, start bit timings: pulse: %3d - %3d, pause: %3d - %3d\n",
+                                        RF_AC104_START_BIT_PULSE_LEN_MIN, RF_AC104_START_BIT_PULSE_LEN_MAX,
+                                        RF_AC104_START_BIT_PAUSE_LEN_MIN, RF_AC104_START_BIT_PAUSE_LEN_MAX);
+                        irmp_param_p = (IRMP_PARAMETER *) &rf_ac104_param;
+//                          memcpy_P (&irmp_param, irmp_param_p, sizeof (IRMP_PARAMETER));
+//                          irmp_address = 0x22;
+//                          irmp_protocol = irmp_param.protocol;
+//                          irmp_command = 0x33;
+//                          irmp_ir_detected= TRUE;
+                    }
+                    else
+#endif // IRMP_SUPPORT_RF_AC104_PROTOCOL == 1
 
 #if IRMP_SUPPORT_RECS80_PROTOCOL == 1
                     if (irmp_pulse_time >= RECS80_START_BIT_PULSE_LEN_MIN && irmp_pulse_time <= RECS80_START_BIT_PULSE_LEN_MAX &&
@@ -5128,6 +5221,32 @@ uint_fast8_t irmp_ISR(void)
                     ANALYZE_PRINTF3 ("%8.3fms code detected, length = %d\n", (double) (time_counter * 1000) / F_INTERRUPTS, irmp_bit);
                     irmp_ir_detected = TRUE;
 
+
+#if IRMP_SUPPORT_RF_AC104_PROTOCOL == 1
+                    if (irmp_param.protocol == RF_AC104_PROTOCOL) {
+                      if(ac104_preamble != 0xA3) 
+                      {
+                          ANALYZE_PRINTF1("wrong preample for AC104 remote\n");
+                          //irmp_tmp_command = ac104_preamble;
+                          irmp_ir_detected = FALSE;
+                      } 
+                      else 
+                      {
+                          uint_fast16_t checksum = (ac104_remote_id & 0xff) + ((ac104_remote_id >> 8) & 0xff) + ((ac104_remote_id >> 16) & 0xff) 
+                                                  + (irmp_tmp_address & 0xff) + ((irmp_tmp_address >> 8) & 0xff) + irmp_tmp_command;
+                          if((checksum & 0xff) != ac104_parity) 
+                          {
+                            ANALYZE_PRINTF1("wrong checksum for AC104 protocol\n");
+                            irmp_ir_detected = FALSE;
+                          }
+                          else if (ac104_remote_id != RF_AC104_IDCHECK)
+                          {
+                            irmp_tmp_address = (ac104_remote_id>>8) & 0xffff;
+                            irmp_tmp_command = ac104_remote_id & 0xff;
+                          }
+                      }
+                    }
+#endif
 #if IRMP_SUPPORT_KATHREIN_PROTOCOL == 1
                     if (irmp_param.protocol == IRMP_KATHREIN_PROTOCOL && irmp_tmp_command == 0x0000)
                     {

--- a/src/irmpArduinoExt.cpp.h
+++ b/src/irmpArduinoExt.cpp.h
@@ -349,6 +349,9 @@ const uint8_t irmp_used_protocol_index[] PROGMEM =
 #if IRMP_SUPPORT_RF_MEDION_PROTOCOL == 1
     RF_MEDION_PROTOCOL
 #endif
+#if IRMP_SUPPORT_RF_HME_PROTOCOL == 1
+    RF_HME_PROTOCOL
+#endif
 };
 
 const char * const irmp_used_protocol_names[] PROGMEM =
@@ -526,6 +529,9 @@ const char * const irmp_used_protocol_names[] PROGMEM =
 #endif
 #if IRMP_SUPPORT_RF_MEDION_PROTOCOL == 1
     proto_rf_medion
+#endif
+#if IRMP_SUPPORT_RF_HME_PROTOCOL == 1
+    proto_rf_hme
 #endif
 };
 

--- a/src/irmpArduinoExt.cpp.h
+++ b/src/irmpArduinoExt.cpp.h
@@ -347,10 +347,13 @@ const uint8_t irmp_used_protocol_index[] PROGMEM =
     RF_X10_PROTOCOL,
 #endif
 #if IRMP_SUPPORT_RF_MEDION_PROTOCOL == 1
-    RF_MEDION_PROTOCOL
+    RF_MEDION_PROTOCOL,
 #endif
 #if IRMP_SUPPORT_RF_HME_PROTOCOL == 1
-    RF_HME_PROTOCOL
+    RF_HME_PROTOCOL,
+#endif
+#if IRMP_SUPPORT_RF_AC104_PROTOCOL == 1
+    RF_AC104_PROTOCOL
 #endif
 };
 
@@ -528,10 +531,13 @@ const char * const irmp_used_protocol_names[] PROGMEM =
     proto_rf_x10,
 #endif
 #if IRMP_SUPPORT_RF_MEDION_PROTOCOL == 1
-    proto_rf_medion
+    proto_rf_medion,
 #endif
 #if IRMP_SUPPORT_RF_HME_PROTOCOL == 1
-    proto_rf_hme
+    proto_rf_hme,
+#endif
+#if IRMP_SUPPORT_RF_AC104_PROTOCOL == 1
+    proto_rf_ac104
 #endif
 };
 

--- a/src/irmpconfig.h
+++ b/src/irmpconfig.h
@@ -146,6 +146,7 @@
 #define IRMP_SUPPORT_RF_X10_PROTOCOL            0       // RF PC X10 (Medion)   >= 15000                 ~250 bytes
 #define IRMP_SUPPORT_RF_MEDION_PROTOCOL         0       // RF PC Medion         >= 15000                 ~250 bytes
 #define IRMP_SUPPORT_RF_HME_PROTOCOL            0       // RF Homeeasy (adv)    >= 15000                 ~250 bytes
+#define IRMP_SUPPORT_RF_AC104_PROTOCOL            0       // RF AC104    >= 15000                 ~250 bytes
 #endif // ! defined(ARDUINO)
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/irmpconfig.h
+++ b/src/irmpconfig.h
@@ -145,6 +145,7 @@
 #define IRMP_SUPPORT_RF_GEN24_PROTOCOL          0       // RF GEN24 (generic)   >= 15000                 ~250 bytes
 #define IRMP_SUPPORT_RF_X10_PROTOCOL            0       // RF PC X10 (Medion)   >= 15000                 ~250 bytes
 #define IRMP_SUPPORT_RF_MEDION_PROTOCOL         0       // RF PC Medion         >= 15000                 ~250 bytes
+#define IRMP_SUPPORT_RF_HME_PROTOCOL            0       // RF Homeeasy (adv)    >= 15000                 ~250 bytes
 #endif // ! defined(ARDUINO)
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/irmpprotocols.c.h
+++ b/src/irmpprotocols.c.h
@@ -81,7 +81,7 @@ const char proto_rf_gen24[]      PROGMEM = "RF_GEN24";
 const char proto_rf_x10[]        PROGMEM = "RF_X10";
 const char proto_rf_medion[]     PROGMEM = "RF_MEDION";
 const char proto_rf_hme[]        PROGMEM = "RF_HOMEEASY";
-
+const char proto_rf_ac104[]      PROGMEM = "RF_AC104";
 
 const char * const
 irmp_protocol_names[IRMP_N_PROTOCOLS + 1] PROGMEM =
@@ -147,7 +147,8 @@ irmp_protocol_names[IRMP_N_PROTOCOLS + 1] PROGMEM =
     proto_rf_gen24,
     proto_rf_x10,
     proto_rf_medion,
-    proto_rf_hme
+    proto_rf_hme,
+    proto_rf_ac104
 };
 
 #endif // _IRMP_PROTOCOLS_C_H_

--- a/src/irmpprotocols.c.h
+++ b/src/irmpprotocols.c.h
@@ -80,6 +80,7 @@ const char proto_onkyo[]         PROGMEM = "ONKYO";
 const char proto_rf_gen24[]      PROGMEM = "RF_GEN24";
 const char proto_rf_x10[]        PROGMEM = "RF_X10";
 const char proto_rf_medion[]     PROGMEM = "RF_MEDION";
+const char proto_rf_hme[]        PROGMEM = "RF_HOMEEASY";
 
 
 const char * const
@@ -145,7 +146,8 @@ irmp_protocol_names[IRMP_N_PROTOCOLS + 1] PROGMEM =
 
     proto_rf_gen24,
     proto_rf_x10,
-    proto_rf_medion
+    proto_rf_medion,
+    proto_rf_hme
 };
 
 #endif // _IRMP_PROTOCOLS_C_H_

--- a/src/irmpprotocols.h
+++ b/src/irmpprotocols.h
@@ -85,8 +85,9 @@
 #define RF_X10_PROTOCOL                         58              // RF PC X10 Remote Control (Medion, Pollin 721815)
 #define RF_MEDION_PROTOCOL                      59              // RF PC Medion Remote Control (Medion)
 #define RF_HME_PROTOCOL                         60              // RF Homeeasy advanced protocol (no dimming)
+#define RF_AC104_PROTOCOL                       61
 
-#define IRMP_N_PROTOCOLS                        60              // number of supported protocols
+#define IRMP_N_PROTOCOLS                        61              // number of supported protocols
 
 #if defined(UNIX_OR_WINDOWS) || IRMP_PROTOCOL_NAMES == 1 || IRSND_PROTOCOL_NAMES == 1
 extern const char proto_unknown[]       PROGMEM;
@@ -151,6 +152,7 @@ extern const char proto_rf_gen24[]      PROGMEM;
 extern const char proto_rf_x10[]        PROGMEM;
 extern const char proto_rf_medion[]     PROGMEM;
 extern const char proto_rf_hme[]        PROGMEM;
+extern const char proto_rf_ac104[]        PROGMEM;
 #endif
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1214,6 +1216,29 @@ typedef uint8_t     PAUSE_LEN;
 #define RF_HME_LSB                               0                               // MSB...LSB
 #define RF_HME_FLAGS                             0                               // flags
 
+/*---------------------------------------------------------------------------------------------------------------------------------------------------
+ * RF AC104 remote control (for shutters / projector screens)
+ *
+ * is a64 bit protocol, 8 bit preamble, 24 bit id, 16 bit address, 8 bit command and 8 bit checksum
+ * we toggle a flag in IRMP to retrieve the ID (TODO), otherwise, we set the RF_AC104_ID fixed and abandon when received
+ *---------------------------------------------------------------------------------------------------------------------------------------------------
+ */
+#define RF_AC104_START_BIT_PULSE_TIME             5300.0e-6                        // 275 usec pulse
+#define RF_AC104_START_BIT_PAUSE_TIME             530.0e-6                        // 2675 usec pause
+#define RF_AC104_0_PULSE_TIME                      270.0e-6                        //  275 usec pulse
+#define RF_AC104_0_PAUSE_TIME                      565.0e-6                        //  275 usec pause
+#define RF_AC104_1_PULSE_TIME                      565.0e-6                        //  275 usec pulse
+#define RF_AC104_1_PAUSE_TIME                     270.0e-6                        // 1225 usec pause
+
+#define RF_AC104_FRAME_REPEAT_PAUSE_TIME          5030.0e-6                        // frame repeat after 10msec
+#define RF_AC104_ADDRESS_OFFSET                   32                               // 
+#define RF_AC104_ADDRESS_LEN                      16                                // needs special preprocessor handling to have enought bits
+#define RF_AC104_COMMAND_OFFSET                   48                                // 16 address bits, actually 26
+#define RF_AC104_COMMAND_LEN                      8                                // read 16 command bits: actually 10 additional addr. bits 
+#define RF_AC104_COMPLETE_DATA_LEN                65                               // complete length
+#define RF_AC104_STOP_BIT                          0                               // has stop bit
+#define RF_AC104_LSB                               0                               // MSB...LSB
+#define RF_AC104_FLAGS                             0                               // flags
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------
  * Frame Repetitions:

--- a/src/irmpprotocols.h
+++ b/src/irmpprotocols.h
@@ -84,8 +84,9 @@
 #define RF_GEN24_PROTOCOL                       57              // RF Generic, 24 Bits (Pollin 550666, EAN 4049702006022 and many other similar RF remote controls))
 #define RF_X10_PROTOCOL                         58              // RF PC X10 Remote Control (Medion, Pollin 721815)
 #define RF_MEDION_PROTOCOL                      59              // RF PC Medion Remote Control (Medion)
+#define RF_HME_PROTOCOL                         60              // RF Homeeasy advanced protocol (no dimming)
 
-#define IRMP_N_PROTOCOLS                        59              // number of supported protocols
+#define IRMP_N_PROTOCOLS                        60              // number of supported protocols
 
 #if defined(UNIX_OR_WINDOWS) || IRMP_PROTOCOL_NAMES == 1 || IRSND_PROTOCOL_NAMES == 1
 extern const char proto_unknown[]       PROGMEM;
@@ -149,6 +150,7 @@ extern const char proto_onkyo[]         PROGMEM;
 extern const char proto_rf_gen24[]      PROGMEM;
 extern const char proto_rf_x10[]        PROGMEM;
 extern const char proto_rf_medion[]     PROGMEM;
+extern const char proto_rf_hme[]        PROGMEM;
 #endif
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1186,6 +1188,31 @@ typedef uint8_t     PAUSE_LEN;
 #define RF_MEDION_STOP_BIT                       1                               // has stop bit
 #define RF_MEDION_LSB                            0                               // MSB...LSB
 #define RF_MEDION_FLAGS                          0                               // flags
+
+
+/*---------------------------------------------------------------------------------------------------------------------------------------------------
+ * RF HOMEEASY remote control (advanced protocol)
+ *
+ * Uses a special "space encoding manchester" combination, see https://homeeasyhacking.fandom.com/wiki/Advanced_Protocol
+ * We decode 'double length' bits as normal space encoding and then convert 01 to 0 and 10 to 1 as we receive them
+ *---------------------------------------------------------------------------------------------------------------------------------------------------
+ */
+#define RF_HME_START_BIT_PULSE_TIME             275.0e-6                        // 275 usec pulse
+#define RF_HME_START_BIT_PAUSE_TIME             2675.0e-6                        // 2675 usec pause
+#define RF_HME_0_PULSE_TIME                      275.0e-6                        //  275 usec pulse
+#define RF_HME_0_PAUSE_TIME                      275.0e-6                        //  275 usec pause
+#define RF_HME_1_PULSE_TIME                      275.0e-6                        //  275 usec pulse
+#define RF_HME_1_PAUSE_TIME                     1225.0e-6                        // 1225 usec pause
+
+#define RF_HME_FRAME_REPEAT_PAUSE_TIME          10.0e-3                        // frame repeat after 10msec
+#define RF_HME_ADDRESS_OFFSET                   0                               // 
+#define RF_HME_ADDRESS_LEN                      16                                // needs special preprocessor handling to have enought bits
+#define RF_HME_COMMAND_OFFSET                   16                                // 16 address bits, actually 26
+#define RF_HME_COMMAND_LEN                      16                                // read 16 command bits: actually 10 additional addr. bits 
+#define RF_HME_COMPLETE_DATA_LEN                32                               // complete length
+#define RF_HME_STOP_BIT                          1                               // has stop bit
+#define RF_HME_LSB                               0                               // MSB...LSB
+#define RF_HME_FLAGS                             0                               // flags
 
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/irmpprotocols.h
+++ b/src/irmpprotocols.h
@@ -1117,12 +1117,13 @@ typedef uint8_t     PAUSE_LEN;
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------
  * RF GEN24 generic remote control (Pollin 550666, EAN 4049702006022 and many other similar RF remote controls)
+ * Slight tweak of timings to work better as sender for homeeasy simple protocol
  *---------------------------------------------------------------------------------------------------------------------------------------------------
  */
-#define RF_GEN24_0_PULSE_TIME                   400.0e-6                        //  400 usec pulse
-#define RF_GEN24_0_PAUSE_TIME                  1066.0e-6                        // 1066 usec pause
-#define RF_GEN24_1_PULSE_TIME                  1066.0e-6                        // 1066 usec pulse
-#define RF_GEN24_1_PAUSE_TIME                   400.0e-6                        //  400 usec pause
+#define RF_GEN24_0_PULSE_TIME                   330.0e-6                        //  400 usec pulse
+#define RF_GEN24_0_PAUSE_TIME                  980.0e-6                        // 1066 usec pause
+#define RF_GEN24_1_PULSE_TIME                  980.0e-6                        // 1066 usec pulse
+#define RF_GEN24_1_PAUSE_TIME                   330.0e-6                        //  400 usec pause
 
 #define RF_GEN24_FRAME_REPEAT_PAUSE_TIME         10.0e-3                        // frame repeat after 10 msec
 #define RF_GEN24_ADDRESS_OFFSET                  0                              // skip 0 bits
@@ -1197,9 +1198,10 @@ typedef uint8_t     PAUSE_LEN;
  *
  * Uses a special "space encoding manchester" combination, see https://homeeasyhacking.fandom.com/wiki/Advanced_Protocol
  * We decode 'double length' bits as normal space encoding and then convert 01 to 0 and 10 to 1 as we receive them
+ * 6 bit command is (MSB to LSB) : group action (1), on/off (1), id within group (4).  Dimming function is not implemented
  *---------------------------------------------------------------------------------------------------------------------------------------------------
  */
-#define RF_HME_START_BIT_PULSE_TIME             275.0e-6                        // 275 usec pulse
+#define RF_HME_START_BIT_PULSE_TIME             275.0e-6                         // 275 usec pulse
 #define RF_HME_START_BIT_PAUSE_TIME             2675.0e-6                        // 2675 usec pause
 #define RF_HME_0_PULSE_TIME                      275.0e-6                        //  275 usec pulse
 #define RF_HME_0_PAUSE_TIME                      275.0e-6                        //  275 usec pause
@@ -1207,36 +1209,36 @@ typedef uint8_t     PAUSE_LEN;
 #define RF_HME_1_PAUSE_TIME                     1225.0e-6                        // 1225 usec pause
 
 #define RF_HME_FRAME_REPEAT_PAUSE_TIME          10.0e-3                        // frame repeat after 10msec
-#define RF_HME_ADDRESS_OFFSET                   0                               // 
-#define RF_HME_ADDRESS_LEN                      16                                // needs special preprocessor handling to have enought bits
-#define RF_HME_COMMAND_OFFSET                   16                                // 16 address bits, actually 26
-#define RF_HME_COMMAND_LEN                      16                                // read 16 command bits: actually 10 additional addr. bits 
-#define RF_HME_COMPLETE_DATA_LEN                32                               // complete length
-#define RF_HME_STOP_BIT                          1                               // has stop bit
-#define RF_HME_LSB                               0                               // MSB...LSB
-#define RF_HME_FLAGS                             0                               // flags
+#define RF_HME_ADDRESS_OFFSET                   0                              
+#define RF_HME_ADDRESS_LEN                      16                             // address is actuall 26 bit (16 + 8 upper bits of command)
+#define RF_HME_COMMAND_OFFSET                   16                             // 16 address bits, actually 26
+#define RF_HME_COMMAND_LEN                      16                             // read 16 command bits: actually 10 additional addr. bits 
+#define RF_HME_COMPLETE_DATA_LEN                32                             // complete length
+#define RF_HME_STOP_BIT                          1                             // has stop bit
+#define RF_HME_LSB                               0                             // MSB...LSB
+#define RF_HME_FLAGS                             0                             // flags
 
 /*---------------------------------------------------------------------------------------------------------------------------------------------------
  * RF AC104 remote control (for shutters / projector screens)
  *
- * is a64 bit protocol, 8 bit preamble, 24 bit id, 16 bit address, 8 bit command and 8 bit checksum
- * we toggle a flag in IRMP to retrieve the ID (TODO), otherwise, we set the RF_AC104_ID fixed and abandon when received
+ * is a64 bit protocol, 8 bit preamble (0xac), 24 bit id, 16 bit address, 8 bit command and 8 bit checksum
+ * if RF_AC104_ID is received as 24bit id, we store the address and command.  Otherwise address (MSB) and command (LSB) will store the received 24bit id
  *---------------------------------------------------------------------------------------------------------------------------------------------------
  */
-#define RF_AC104_START_BIT_PULSE_TIME             5300.0e-6                        // 275 usec pulse
-#define RF_AC104_START_BIT_PAUSE_TIME             530.0e-6                        // 2675 usec pause
-#define RF_AC104_0_PULSE_TIME                      270.0e-6                        //  275 usec pulse
-#define RF_AC104_0_PAUSE_TIME                      565.0e-6                        //  275 usec pause
-#define RF_AC104_1_PULSE_TIME                      565.0e-6                        //  275 usec pulse
-#define RF_AC104_1_PAUSE_TIME                     270.0e-6                        // 1225 usec pause
+#define RF_AC104_START_BIT_PULSE_TIME             5300.0e-6                        // 5300 usec pulse
+#define RF_AC104_START_BIT_PAUSE_TIME              530.0e-6                        // 530 usec pause
+#define RF_AC104_0_PULSE_TIME                      200.0e-6                        // 200 usec pulse
+#define RF_AC104_0_PAUSE_TIME                      580.0e-6                        //  580 usec pause
+#define RF_AC104_1_PULSE_TIME                      580.0e-6                        //  580 usec pulse
+#define RF_AC104_1_PAUSE_TIME                      200.0e-6                        // 200 usec pause
 
-#define RF_AC104_FRAME_REPEAT_PAUSE_TIME          150.0e-6                        // frame repeat after 10msec
-#define RF_AC104_ADDRESS_OFFSET                   32                               // 
-#define RF_AC104_ADDRESS_LEN                      16                                // needs special preprocessor handling to have enought bits
-#define RF_AC104_COMMAND_OFFSET                   48                                // 16 address bits, actually 26
-#define RF_AC104_COMMAND_LEN                      8                                // read 16 command bits: actually 10 additional addr. bits 
-#define RF_AC104_COMPLETE_DATA_LEN                65                               // complete length
-#define RF_AC104_STOP_BIT                          0                               // has stop bit
+#define RF_AC104_FRAME_REPEAT_PAUSE_TIME           150.0e-6                        // super short frame repeat (150usec).  Needed for sending
+#define RF_AC104_ADDRESS_OFFSET                    32                              // 
+#define RF_AC104_ADDRESS_LEN                       16                              // 16 bit address (each bit corresponds to one of 16 senders)
+#define RF_AC104_COMMAND_OFFSET                    48                              // 8 bit preamble + 24 id + 16 address
+#define RF_AC104_COMMAND_LEN                       8                               // read 8 command bits, 0x0b: up, 0x23 stop, 0x43 down, 0x24 after 
+#define RF_AC104_COMPLETE_DATA_LEN                 65                              // complete length (including trailing 1)
+#define RF_AC104_STOP_BIT                          0                               // has no stop bit, but trailing 1
 #define RF_AC104_LSB                               0                               // MSB...LSB
 #define RF_AC104_FLAGS                             0                               // flags
 

--- a/src/irmpprotocols.h
+++ b/src/irmpprotocols.h
@@ -1230,7 +1230,7 @@ typedef uint8_t     PAUSE_LEN;
 #define RF_AC104_1_PULSE_TIME                      565.0e-6                        //  275 usec pulse
 #define RF_AC104_1_PAUSE_TIME                     270.0e-6                        // 1225 usec pause
 
-#define RF_AC104_FRAME_REPEAT_PAUSE_TIME          5030.0e-6                        // frame repeat after 10msec
+#define RF_AC104_FRAME_REPEAT_PAUSE_TIME          150.0e-6                        // frame repeat after 10msec
 #define RF_AC104_ADDRESS_OFFSET                   32                               // 
 #define RF_AC104_ADDRESS_LEN                      16                                // needs special preprocessor handling to have enought bits
 #define RF_AC104_COMMAND_OFFSET                   48                                // 16 address bits, actually 26

--- a/src/irsnd.c.h
+++ b/src/irsnd.c.h
@@ -1089,7 +1089,7 @@ static uint8_t hme_manchester_converter(uint8_t code) // only considers the lowe
 #if IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
 #define RF_AC104_PREAMBLE  0xA3
 #ifndef RF_AC104_ID
-#define RF_AC104_ID        0x4647a8
+#define RF_AC104_ID        0  //preferably defined in main program
 #endif
 static const uint16_t rf_ac104_parity_id=((RF_AC104_ID >> 16) + (RF_AC104_ID >> 8) + RF_AC104_ID) & 0xff;
 #endif // IRMP_SUPPORT_RF_AC104_PROTOCOL

--- a/src/irsnd.c.h
+++ b/src/irsnd.c.h
@@ -475,6 +475,36 @@
 #define IRSND_ACP24_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * ACP24_0_PAUSE_TIME + 0.5)
 #define IRSND_ACP24_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * ACP24_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
 
+#define IRSND_RF_LATENCY                              (50.0e-6) //50 us latency
+
+#define IRSND_RF_GEN24_START_BIT_PULSE_LEN             0
+#define IRSND_RF_GEN24_START_BIT_PAUSE_LEN             0
+#define IRSND_RF_GEN24_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * RF_GEN24_REPEAT_START_BIT_PAUSE_TIME + 0.5)
+#define IRSND_RF_GEN24_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_GEN24_1_PULSE_TIME + 0.5)
+#define IRSND_RF_GEN24_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_GEN24_0_PULSE_TIME + 0.5)
+#define IRSND_RF_GEN24_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_GEN24_1_PAUSE_TIME + 0.5)
+#define IRSND_RF_GEN24_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_GEN24_0_PAUSE_TIME + 0.5)
+#define IRSND_RF_GEN24_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * RF_GEN24_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
+
+#define IRSND_RF_HME_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_HME_START_BIT_PULSE_TIME - IRSND_RF_LATENCY)+ 0.5)
+#define IRSND_RF_HME_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_HME_START_BIT_PAUSE_TIME + IRSND_RF_LATENCY)+ 0.5)
+#define IRSND_RF_HME_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * RF_HME_REPEAT_START_BIT_PAUSE_TIME + 0.5)
+#define IRSND_RF_HME_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_HME_1_PULSE_TIME - IRSND_RF_LATENCY)+ 0.5)
+#define IRSND_RF_HME_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_HME_0_PULSE_TIME - IRSND_RF_LATENCY)+ 0.5)
+#define IRSND_RF_HME_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_HME_1_PAUSE_TIME + IRSND_RF_LATENCY)+ 0.5)
+#define IRSND_RF_HME_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_HME_0_PAUSE_TIME + IRSND_RF_LATENCY)+ 0.5)
+#define IRSND_RF_HME_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * RF_HME_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
+
+#define IRSND_RF_AC104_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * RF_AC104_START_BIT_PULSE_TIME + 0.5)
+#define IRSND_RF_AC104_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * RF_AC104_START_BIT_PAUSE_TIME + 0.5)
+#define IRSND_RF_AC104_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * RF_AC104_REPEAT_START_BIT_PAUSE_TIME + 0.5)
+#define IRSND_RF_AC104_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_AC104_1_PULSE_TIME + 0.5)
+#define IRSND_RF_AC104_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_AC104_0_PULSE_TIME + 0.5)
+#define IRSND_RF_AC104_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_AC104_1_PAUSE_TIME + 0.5)
+#define IRSND_RF_AC104_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_AC104_0_PAUSE_TIME + 0.5)
+#define IRSND_RF_AC104_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * RF_AC104_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
+
+
 #ifdef PIC_C18                                  // PIC C18
 #  define IRSND_FREQ_TYPE                       uint8_t
 #  define IRSND_FREQ_30_KHZ                     (IRSND_FREQ_TYPE) ((F_CPU / 30000  / 2 / Pre_Scaler / PIC_Scaler) - 1)
@@ -543,6 +573,10 @@ volatile uint8_t                                irsnd_is_on = FALSE;
 static volatile uint8_t                         irsnd_protocol = 0;
 static volatile uint8_t                         irsnd_buffer[11] = {0};
 static volatile uint8_t                         irsnd_repeat = 0;
+
+#if defined(IRSND_RF_OUTPUT)
+static volatile uint8_t                         irsnd_rf = 0;
+#endif
 
 #if defined(ARDUINO)
 #include "irsndArduinoExt.cpp.h" // must be after the declarations of irsnd_busy etc.
@@ -1036,6 +1070,21 @@ bitsrevervse (uint16_t x, uint8_t len)
     return xx;
 }
 
+
+#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
+static uint8_t hme_manchester_converter(uint8_t code) // only considers the lower 4 bits
+{
+    uint8_t output = 0;
+    uint8_t pos=4;
+    while(pos) {
+       pos--;
+       uint8_t s_bit=(code & (1<<pos)) >> pos;
+       output <<= 2;
+       output |= (s_bit << 1) | (~s_bit & 1);
+    }
+    return output;
+}
+#endif
 
 #if IRSND_SUPPORT_SIRCS_PROTOCOL == 1
 static uint8_t  sircs_additional_bitlen;
@@ -1702,7 +1751,22 @@ irsnd_send_data (IRMP_DATA * irmp_data_p, uint8_t do_wait)
             break;
         }
 #endif
-
+#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
+        case RF_HME_PROTOCOL:
+        {
+            irsnd_buffer[0] = hme_manchester_converter((irmp_data_p->address >> 12) & 0xF);
+            irsnd_buffer[1] = hme_manchester_converter((irmp_data_p->address >> 8) & 0xF);
+            irsnd_buffer[2] = hme_manchester_converter((irmp_data_p->address >> 4) & 0xF);
+            irsnd_buffer[3] = hme_manchester_converter(irmp_data_p->address & 0xF);
+            irsnd_buffer[4] = hme_manchester_converter((irmp_data_p->command >> 12) & 0xF);
+            irsnd_buffer[5] = hme_manchester_converter((irmp_data_p->command >> 8) & 0xF);
+            irsnd_buffer[6] = hme_manchester_converter((irmp_data_p->command >> 4) & 0xF);
+            irsnd_buffer[7] = hme_manchester_converter(irmp_data_p->command & 0xF);
+            
+            irsnd_busy = TRUE;
+            break;
+        }
+#endif
         default:
         {
             break;
@@ -2611,6 +2675,24 @@ irsnd_ISR (void)
                         break;
                     }
 #endif
+#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
+                    case RF_HME_PROTOCOL:
+                    {
+                        startbit_pulse_len          = IRSND_RF_HME_START_BIT_PULSE_LEN;
+                        startbit_pause_len          = IRSND_RF_HME_START_BIT_PAUSE_LEN - 1;
+                        complete_data_len           = RF_HME_COMPLETE_DATA_LEN * 2;
+                        pulse_1_len                 = IRSND_RF_HME_1_PULSE_LEN;
+                        pause_1_len                 = IRSND_RF_HME_1_PAUSE_LEN - 1;
+                        pulse_0_len                 = IRSND_RF_HME_0_PULSE_LEN;
+                        pause_0_len                 = IRSND_RF_HME_0_PAUSE_LEN - 1;
+                        has_stop_bit                = RF_HME_STOP_BIT;
+                        n_auto_repetitions          = 4;                                                    // 4 frames
+                        auto_repetition_pause_len   = IRSND_RF_HME_FRAME_REPEAT_PAUSE_LEN;
+                        repeat_frame_pause_len      = IRSND_RF_HME_FRAME_REPEAT_PAUSE_LEN;
+                        irsnd_rf                    = 1;
+                        break;
+                    }
+#endif
                     default:
                     {
                         irsnd_busy = FALSE;
@@ -2721,6 +2803,9 @@ irsnd_ISR (void)
 #if IRSND_SUPPORT_ACP24_PROTOCOL == 1
                 case IRMP_ACP24_PROTOCOL:
 #endif
+#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
+                case RF_HME_PROTOCOL:
+#endif
 
 #if IRSND_SUPPORT_SIRCS_PROTOCOL == 1  || IRSND_SUPPORT_NEC_PROTOCOL == 1 || IRSND_SUPPORT_NEC16_PROTOCOL == 1 || IRSND_SUPPORT_NEC42_PROTOCOL == 1 || \
     IRSND_SUPPORT_LGAIR_PROTOCOL == 1 || IRSND_SUPPORT_SAMSUNG_PROTOCOL == 1 || IRSND_SUPPORT_MATSUSHITA_PROTOCOL == 1 || IRSND_SUPPORT_TECHNICS_PROTOCOL == 1 || \
@@ -2729,7 +2814,7 @@ irsnd_ISR (void)
     IRSND_SUPPORT_FDC_PROTOCOL == 1 || IRSND_SUPPORT_RCCAR_PROTOCOL == 1 || IRSND_SUPPORT_JVC_PROTOCOL == 1 || IRSND_SUPPORT_NIKON_PROTOCOL == 1 || \
     IRSND_SUPPORT_LEGO_PROTOCOL == 1 || IRSND_SUPPORT_THOMSON_PROTOCOL == 1 || IRSND_SUPPORT_ROOMBA_PROTOCOL == 1 || IRSND_SUPPORT_TELEFUNKEN_PROTOCOL == 1 || \
     IRSND_SUPPORT_PENTAX_PROTOCOL == 1 || IRSND_SUPPORT_ACP24_PROTOCOL == 1 || IRSND_SUPPORT_PANASONIC_PROTOCOL == 1 || IRSND_SUPPORT_BOSE_PROTOCOL == 1 || \
-    IRSND_SUPPORT_MITSU_HEAVY_PROTOCOL == 1 || IRSND_SUPPORT_IRMP16_PROTOCOL == 1
+    IRSND_SUPPORT_MITSU_HEAVY_PROTOCOL == 1 || IRSND_SUPPORT_IRMP16_PROTOCOL == 1 || IRSND_SUPPORT_RF_HME_PROTOCOL == 1
                 {
                     if (pulse_counter == 0)
                     {
@@ -2888,6 +2973,9 @@ irsnd_ISR (void)
                             {
                                 irsnd_busy = FALSE;
                                 auto_repetition_counter = 0;
+#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
+                                irsnd_rf = 0; //no need to check for protocol, turn off rf anyway
+#endif 
                             }
                             new_frame = TRUE;
                         }

--- a/src/irsnd.c.h
+++ b/src/irsnd.c.h
@@ -475,8 +475,6 @@
 #define IRSND_ACP24_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * ACP24_0_PAUSE_TIME + 0.5)
 #define IRSND_ACP24_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * ACP24_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
 
-#define IRSND_RF_LATENCY                              (50.0e-6) //50 us latency
-
 #define IRSND_RF_GEN24_START_BIT_PULSE_LEN             0
 #define IRSND_RF_GEN24_START_BIT_PAUSE_LEN             0
 #define IRSND_RF_GEN24_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * RF_GEN24_REPEAT_START_BIT_PAUSE_TIME + 0.5)
@@ -486,23 +484,23 @@
 #define IRSND_RF_GEN24_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_GEN24_0_PAUSE_TIME + 0.5)
 #define IRSND_RF_GEN24_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * RF_GEN24_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
 
-#define IRSND_RF_HME_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_HME_START_BIT_PULSE_TIME - IRSND_RF_LATENCY)+ 0.5)
-#define IRSND_RF_HME_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_HME_START_BIT_PAUSE_TIME + IRSND_RF_LATENCY)+ 0.5)
+#define IRSND_RF_HME_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * RF_HME_START_BIT_PULSE_TIME + 0.5)
+#define IRSND_RF_HME_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * RF_HME_START_BIT_PAUSE_TIME + 0.5)
 #define IRSND_RF_HME_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * RF_HME_REPEAT_START_BIT_PAUSE_TIME + 0.5)
-#define IRSND_RF_HME_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_HME_1_PULSE_TIME - IRSND_RF_LATENCY)+ 0.5)
-#define IRSND_RF_HME_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_HME_0_PULSE_TIME - IRSND_RF_LATENCY)+ 0.5)
-#define IRSND_RF_HME_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_HME_1_PAUSE_TIME + IRSND_RF_LATENCY)+ 0.5)
-#define IRSND_RF_HME_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_HME_0_PAUSE_TIME + IRSND_RF_LATENCY)+ 0.5)
+#define IRSND_RF_HME_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_HME_1_PULSE_TIME + 0.5)
+#define IRSND_RF_HME_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_HME_0_PULSE_TIME + 0.5)
+#define IRSND_RF_HME_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_HME_1_PAUSE_TIME + 0.5)
+#define IRSND_RF_HME_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_HME_0_PAUSE_TIME + 0.5)
 #define IRSND_RF_HME_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * RF_HME_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
 
-#define IRSND_RF_AC104_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * RF_AC104_START_BIT_PULSE_TIME + 0.5)
-#define IRSND_RF_AC104_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * RF_AC104_START_BIT_PAUSE_TIME + 0.5)
-#define IRSND_RF_AC104_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * RF_AC104_REPEAT_START_BIT_PAUSE_TIME + 0.5)
-#define IRSND_RF_AC104_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_AC104_1_PULSE_TIME + 0.5)
-#define IRSND_RF_AC104_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_AC104_0_PULSE_TIME + 0.5)
-#define IRSND_RF_AC104_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_AC104_1_PAUSE_TIME + 0.5)
-#define IRSND_RF_AC104_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_AC104_0_PAUSE_TIME + 0.5)
-#define IRSND_RF_AC104_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * RF_AC104_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
+#define IRSND_RF_AC104_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_AC104_START_BIT_PULSE_TIME) + 0.5) //+ IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_AC104_START_BIT_PAUSE_TIME) + 0.5) //- IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * (RF_AC104_REPEAT_START_BIT_PAUSE_TIME) + 0.5) // - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_AC104_1_PULSE_TIME) + 0.5) // + IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_AC104_0_PULSE_TIME) + 0.5) // + IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_AC104_1_PAUSE_TIME) + 0.5) // - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_AC104_0_PAUSE_TIME) + 0.5) // - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * (RF_AC104_FRAME_REPEAT_PAUSE_TIME) + 0.5) // - IRSND_RF_LATENCY) + 0.5)                // use uint16_t!
 
 
 #ifdef PIC_C18                                  // PIC C18
@@ -1085,6 +1083,15 @@ static uint8_t hme_manchester_converter(uint8_t code) // only considers the lowe
     return output;
 }
 #endif
+
+#if IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
+#define RF_AC104_PREAMBLE  0xA3
+#ifndef RF_AC104_ID
+#define RF_AC104_ID        0x4647a8
+#endif
+static const uint16_t rf_ac104_parity_id=((RF_AC104_ID >> 16) + (RF_AC104_ID >> 8) + RF_AC104_ID) & 0xff;
+#endif // IRMP_SUPPORT_RF_AC104_PROTOCOL
+
 
 #if IRSND_SUPPORT_SIRCS_PROTOCOL == 1
 static uint8_t  sircs_additional_bitlen;
@@ -1762,6 +1769,23 @@ irsnd_send_data (IRMP_DATA * irmp_data_p, uint8_t do_wait)
             irsnd_buffer[5] = hme_manchester_converter((irmp_data_p->command >> 8) & 0xF);
             irsnd_buffer[6] = hme_manchester_converter((irmp_data_p->command >> 4) & 0xF);
             irsnd_buffer[7] = hme_manchester_converter(irmp_data_p->command & 0xF);
+            
+            irsnd_busy = TRUE;
+            break;
+        }
+#endif
+#if IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
+        case RF_AC104_PROTOCOL:
+        {
+            irsnd_buffer[0] = RF_AC104_PREAMBLE;
+            irsnd_buffer[1] = (RF_AC104_ID >> 16) & 0xff;
+            irsnd_buffer[2] = (RF_AC104_ID >> 8) & 0xff;
+            irsnd_buffer[3] = RF_AC104_ID & 0xff;
+            irsnd_buffer[4] = (irmp_data_p->address >> 8) & 0xff;
+            irsnd_buffer[5] = irmp_data_p->address & 0xff;
+            irsnd_buffer[6] = irmp_data_p->command & 0xff;
+            irsnd_buffer[7] = ((irmp_data_p->address >> 8) + irmp_data_p->address + irmp_data_p->command + rf_ac104_parity_id ) & 0xff;
+            irsnd_buffer[8] = 0x80; //send '1' to terminate
             
             irsnd_busy = TRUE;
             break;
@@ -2693,6 +2717,24 @@ irsnd_ISR (void)
                         break;
                     }
 #endif
+#if IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
+                    case RF_AC104_PROTOCOL:
+                    {
+                        startbit_pulse_len          = IRSND_RF_AC104_START_BIT_PULSE_LEN;
+                        startbit_pause_len          = IRSND_RF_AC104_START_BIT_PAUSE_LEN - 1;
+                        complete_data_len           = RF_AC104_COMPLETE_DATA_LEN;
+                        pulse_1_len                 = IRSND_RF_AC104_1_PULSE_LEN;
+                        pause_1_len                 = IRSND_RF_AC104_1_PAUSE_LEN - 1;
+                        pulse_0_len                 = IRSND_RF_AC104_0_PULSE_LEN;
+                        pause_0_len                 = IRSND_RF_AC104_0_PAUSE_LEN - 1;
+                        has_stop_bit                = RF_AC104_STOP_BIT;
+                        n_auto_repetitions          = 4;                                                    // 4 frames
+                        auto_repetition_pause_len   = IRSND_RF_AC104_FRAME_REPEAT_PAUSE_LEN;
+                        repeat_frame_pause_len      = IRSND_RF_AC104_FRAME_REPEAT_PAUSE_LEN;
+                        irsnd_rf                    = 1;
+                        break;
+                    }
+#endif
                     default:
                     {
                         irsnd_busy = FALSE;
@@ -2806,6 +2848,9 @@ irsnd_ISR (void)
 #if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
                 case RF_HME_PROTOCOL:
 #endif
+#if IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
+                case RF_AC104_PROTOCOL:
+#endif
 
 #if IRSND_SUPPORT_SIRCS_PROTOCOL == 1  || IRSND_SUPPORT_NEC_PROTOCOL == 1 || IRSND_SUPPORT_NEC16_PROTOCOL == 1 || IRSND_SUPPORT_NEC42_PROTOCOL == 1 || \
     IRSND_SUPPORT_LGAIR_PROTOCOL == 1 || IRSND_SUPPORT_SAMSUNG_PROTOCOL == 1 || IRSND_SUPPORT_MATSUSHITA_PROTOCOL == 1 || IRSND_SUPPORT_TECHNICS_PROTOCOL == 1 || \
@@ -2814,7 +2859,7 @@ irsnd_ISR (void)
     IRSND_SUPPORT_FDC_PROTOCOL == 1 || IRSND_SUPPORT_RCCAR_PROTOCOL == 1 || IRSND_SUPPORT_JVC_PROTOCOL == 1 || IRSND_SUPPORT_NIKON_PROTOCOL == 1 || \
     IRSND_SUPPORT_LEGO_PROTOCOL == 1 || IRSND_SUPPORT_THOMSON_PROTOCOL == 1 || IRSND_SUPPORT_ROOMBA_PROTOCOL == 1 || IRSND_SUPPORT_TELEFUNKEN_PROTOCOL == 1 || \
     IRSND_SUPPORT_PENTAX_PROTOCOL == 1 || IRSND_SUPPORT_ACP24_PROTOCOL == 1 || IRSND_SUPPORT_PANASONIC_PROTOCOL == 1 || IRSND_SUPPORT_BOSE_PROTOCOL == 1 || \
-    IRSND_SUPPORT_MITSU_HEAVY_PROTOCOL == 1 || IRSND_SUPPORT_IRMP16_PROTOCOL == 1 || IRSND_SUPPORT_RF_HME_PROTOCOL == 1
+    IRSND_SUPPORT_MITSU_HEAVY_PROTOCOL == 1 || IRSND_SUPPORT_IRMP16_PROTOCOL == 1 || IRSND_SUPPORT_RF_HME_PROTOCOL == 1 || IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
                 {
                     if (pulse_counter == 0)
                     {
@@ -2973,7 +3018,7 @@ irsnd_ISR (void)
                             {
                                 irsnd_busy = FALSE;
                                 auto_repetition_counter = 0;
-#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
+#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1 || IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
                                 irsnd_rf = 0; //no need to check for protocol, turn off rf anyway
 #endif 
                             }

--- a/src/irsnd.c.h
+++ b/src/irsnd.c.h
@@ -475,31 +475,33 @@
 #define IRSND_ACP24_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * ACP24_0_PAUSE_TIME + 0.5)
 #define IRSND_ACP24_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * ACP24_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
 
+#define IRSND_RF_LATENCY                            40.0e-6 //usec
+
 #define IRSND_RF_GEN24_START_BIT_PULSE_LEN             0
 #define IRSND_RF_GEN24_START_BIT_PAUSE_LEN             0
-#define IRSND_RF_GEN24_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * RF_GEN24_REPEAT_START_BIT_PAUSE_TIME + 0.5)
-#define IRSND_RF_GEN24_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_GEN24_1_PULSE_TIME + 0.5)
-#define IRSND_RF_GEN24_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_GEN24_0_PULSE_TIME + 0.5)
-#define IRSND_RF_GEN24_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_GEN24_1_PAUSE_TIME + 0.5)
-#define IRSND_RF_GEN24_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_GEN24_0_PAUSE_TIME + 0.5)
+#define IRSND_RF_GEN24_REPEAT_START_BIT_PAUSE_LEN      0  //(uint8_t)(F_INTERRUPTS * RF_GEN24_REPEAT_START_BIT_PAUSE_TIME + 0.5)
+#define IRSND_RF_GEN24_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_GEN24_1_PULSE_TIME - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_GEN24_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_GEN24_0_PULSE_TIME - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_GEN24_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_GEN24_1_PAUSE_TIME + IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_GEN24_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_GEN24_0_PAUSE_TIME + IRSND_RF_LATENCY) + 0.5)
 #define IRSND_RF_GEN24_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * RF_GEN24_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
 
-#define IRSND_RF_HME_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * RF_HME_START_BIT_PULSE_TIME + 0.5)
-#define IRSND_RF_HME_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * RF_HME_START_BIT_PAUSE_TIME + 0.5)
-#define IRSND_RF_HME_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * RF_HME_REPEAT_START_BIT_PAUSE_TIME + 0.5)
-#define IRSND_RF_HME_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_HME_1_PULSE_TIME + 0.5)
-#define IRSND_RF_HME_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * RF_HME_0_PULSE_TIME + 0.5)
-#define IRSND_RF_HME_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_HME_1_PAUSE_TIME + 0.5)
-#define IRSND_RF_HME_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * RF_HME_0_PAUSE_TIME + 0.5)
+#define IRSND_RF_HME_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_HME_START_BIT_PULSE_TIME - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_HME_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_HME_START_BIT_PAUSE_TIME + IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_HME_REPEAT_START_BIT_PAUSE_LEN      0 // (uint8_t)(F_INTERRUPTS * RF_HME_REPEAT_START_BIT_PAUSE_TIME + 0.5)
+#define IRSND_RF_HME_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_HME_1_PULSE_TIME - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_HME_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_HME_0_PULSE_TIME - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_HME_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_HME_1_PAUSE_TIME + IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_HME_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_HME_0_PAUSE_TIME + IRSND_RF_LATENCY) + 0.5)
 #define IRSND_RF_HME_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * RF_HME_FRAME_REPEAT_PAUSE_TIME + 0.5)                // use uint16_t!
 
-#define IRSND_RF_AC104_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_AC104_START_BIT_PULSE_TIME) + 0.5) //+ IRSND_RF_LATENCY) + 0.5)
-#define IRSND_RF_AC104_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_AC104_START_BIT_PAUSE_TIME) + 0.5) //- IRSND_RF_LATENCY) + 0.5)
-#define IRSND_RF_AC104_REPEAT_START_BIT_PAUSE_LEN      (uint8_t)(F_INTERRUPTS * (RF_AC104_REPEAT_START_BIT_PAUSE_TIME) + 0.5) // - IRSND_RF_LATENCY) + 0.5)
-#define IRSND_RF_AC104_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_AC104_1_PULSE_TIME) + 0.5) // + IRSND_RF_LATENCY) + 0.5)
-#define IRSND_RF_AC104_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_AC104_0_PULSE_TIME) + 0.5) // + IRSND_RF_LATENCY) + 0.5)
-#define IRSND_RF_AC104_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_AC104_1_PAUSE_TIME) + 0.5) // - IRSND_RF_LATENCY) + 0.5)
-#define IRSND_RF_AC104_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_AC104_0_PAUSE_TIME) + 0.5) // - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_START_BIT_PULSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_AC104_START_BIT_PULSE_TIME - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_START_BIT_PAUSE_LEN             (uint8_t)(F_INTERRUPTS * (RF_AC104_START_BIT_PAUSE_TIME + IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_REPEAT_START_BIT_PAUSE_LEN      0 // (uint8_t)(F_INTERRUPTS * (RF_AC104_REPEAT_START_BIT_PAUSE_TIME) + 0.5) // - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_1_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_AC104_1_PULSE_TIME - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_0_PULSE_LEN                       (uint8_t)(F_INTERRUPTS * (RF_AC104_0_PULSE_TIME - IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_1_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_AC104_1_PAUSE_TIME + IRSND_RF_LATENCY) + 0.5)
+#define IRSND_RF_AC104_0_PAUSE_LEN                     (uint8_t)(F_INTERRUPTS * (RF_AC104_0_PAUSE_TIME + IRSND_RF_LATENCY) + 0.5)
 #define IRSND_RF_AC104_FRAME_REPEAT_PAUSE_LEN          (uint16_t)(F_INTERRUPTS * (RF_AC104_FRAME_REPEAT_PAUSE_TIME) + 0.5) // - IRSND_RF_LATENCY) + 0.5)                // use uint16_t!
 
 
@@ -1758,6 +1760,17 @@ irsnd_send_data (IRMP_DATA * irmp_data_p, uint8_t do_wait)
             break;
         }
 #endif
+#if IRSND_SUPPORT_RF_GEN24_PROTOCOL == 1
+        case RF_GEN24_PROTOCOL:
+        {
+            irsnd_buffer[0] = (irmp_data_p->address >> 2) & 0xFF;
+            irsnd_buffer[1] = ((irmp_data_p->address << 6 ) & 0xFF) | ((irmp_data_p->command >>8) & 0xFF);
+            irsnd_buffer[2] = irmp_data_p->command & 0xFF;
+            
+            irsnd_busy = TRUE;
+            break;
+        }
+#endif
 #if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
         case RF_HME_PROTOCOL:
         {
@@ -2699,6 +2712,24 @@ irsnd_ISR (void)
                         break;
                     }
 #endif
+#if IRSND_SUPPORT_RF_GEN24_PROTOCOL == 1
+                    case RF_GEN24_PROTOCOL:
+                    {
+                        startbit_pulse_len          = 0; //IRSND_RF_GEN24_START_BIT_PULSE_LEN;
+                        startbit_pause_len          = 0; //IRSND_RF_GEN24_START_BIT_PAUSE_LEN - 1;
+                        complete_data_len           = RF_GEN24_COMPLETE_DATA_LEN;
+                        pulse_1_len                 = IRSND_RF_GEN24_1_PULSE_LEN;
+                        pause_1_len                 = IRSND_RF_GEN24_1_PAUSE_LEN - 1;
+                        pulse_0_len                 = IRSND_RF_GEN24_0_PULSE_LEN;
+                        pause_0_len                 = IRSND_RF_GEN24_0_PAUSE_LEN - 1;
+                        has_stop_bit                = RF_GEN24_STOP_BIT;
+                        n_auto_repetitions          = 4;                                                    // 4 frames
+                        auto_repetition_pause_len   = IRSND_RF_GEN24_FRAME_REPEAT_PAUSE_LEN;
+                        repeat_frame_pause_len      = IRSND_RF_GEN24_FRAME_REPEAT_PAUSE_LEN;
+                        irsnd_rf                    = 1;
+                        break;
+                    }
+#endif
 #if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
                     case RF_HME_PROTOCOL:
                     {
@@ -2845,6 +2876,9 @@ irsnd_ISR (void)
 #if IRSND_SUPPORT_ACP24_PROTOCOL == 1
                 case IRMP_ACP24_PROTOCOL:
 #endif
+#if IRSND_SUPPORT_RF_GEN24_PROTOCOL == 1
+                case RF_GEN24_PROTOCOL:
+#endif
 #if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
                 case RF_HME_PROTOCOL:
 #endif
@@ -2859,7 +2893,8 @@ irsnd_ISR (void)
     IRSND_SUPPORT_FDC_PROTOCOL == 1 || IRSND_SUPPORT_RCCAR_PROTOCOL == 1 || IRSND_SUPPORT_JVC_PROTOCOL == 1 || IRSND_SUPPORT_NIKON_PROTOCOL == 1 || \
     IRSND_SUPPORT_LEGO_PROTOCOL == 1 || IRSND_SUPPORT_THOMSON_PROTOCOL == 1 || IRSND_SUPPORT_ROOMBA_PROTOCOL == 1 || IRSND_SUPPORT_TELEFUNKEN_PROTOCOL == 1 || \
     IRSND_SUPPORT_PENTAX_PROTOCOL == 1 || IRSND_SUPPORT_ACP24_PROTOCOL == 1 || IRSND_SUPPORT_PANASONIC_PROTOCOL == 1 || IRSND_SUPPORT_BOSE_PROTOCOL == 1 || \
-    IRSND_SUPPORT_MITSU_HEAVY_PROTOCOL == 1 || IRSND_SUPPORT_IRMP16_PROTOCOL == 1 || IRSND_SUPPORT_RF_HME_PROTOCOL == 1 || IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
+    IRSND_SUPPORT_MITSU_HEAVY_PROTOCOL == 1 || IRSND_SUPPORT_IRMP16_PROTOCOL == 1 || IRSND_SUPPORT_RF_HME_PROTOCOL == 1 || IRSND_SUPPORT_RF_AC104_PROTOCOL == 1 || \
+    IRSND_SUPPORT_RF_GEN24_PROTOCOL == 1
                 {
                     if (pulse_counter == 0)
                     {
@@ -3018,7 +3053,7 @@ irsnd_ISR (void)
                             {
                                 irsnd_busy = FALSE;
                                 auto_repetition_counter = 0;
-#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1 || IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
+#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1 || IRSND_SUPPORT_RF_AC104_PROTOCOL == 1 || IRSND_SUPPORT_RF_GEN24_PROTOCOL
                                 irsnd_rf = 0; //no need to check for protocol, turn off rf anyway
 #endif 
                             }

--- a/src/irsndArduinoExt.cpp.h
+++ b/src/irsndArduinoExt.cpp.h
@@ -336,6 +336,9 @@ const uint8_t irsnd_used_protocol_index[] PROGMEM =
 #if IRMP_SUPPORT_RF_MEDION_PROTOCOL == 1
     RF_MEDION_PROTOCOL
 #endif
+#if IRMP_SUPPORT_RF_HME_PROTOCOL == 1
+    RF_HME_PROTOCOL
+#endif
 };
 
 const char * const irsnd_used_protocol_names[] PROGMEM =
@@ -510,6 +513,9 @@ const char * const irsnd_used_protocol_names[] PROGMEM =
 #endif
 #if IRSND_SUPPORT_RF_MEDION_PROTOCOL == 1
     proto_rf_medion
+#endif
+#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
+    proto_rf_hme
 #endif
 };
 

--- a/src/irsndArduinoExt.cpp.h
+++ b/src/irsndArduinoExt.cpp.h
@@ -521,7 +521,7 @@ const char * const irsnd_used_protocol_names[] PROGMEM =
     proto_rf_medion,
 #endif
 #if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
-    proto_rf_hme
+    proto_rf_hme,
 #endif
 #if IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
     proto_rf_ac104

--- a/src/irsndArduinoExt.cpp.h
+++ b/src/irsndArduinoExt.cpp.h
@@ -80,6 +80,9 @@ void irsnd_init(void)
 {
     // Do not call irsnd_init_and_store_timer() here, it is done at irsnd_send_data().
     pinModeFast(IRSND_OUTPUT_PIN, OUTPUT);
+#  ifdef IRSND_RF_OUTPUT
+    pinModeFast(IRSND_RF_PIN,OUTPUT);
+#  endif
 #  ifdef IRMP_MEASURE_TIMING
     pinModeFast(IRMP_TIMING_TEST_PIN, OUTPUT);
 #  endif
@@ -334,10 +337,13 @@ const uint8_t irsnd_used_protocol_index[] PROGMEM =
     RF_X10_PROTOCOL,
 #endif
 #if IRMP_SUPPORT_RF_MEDION_PROTOCOL == 1
-    RF_MEDION_PROTOCOL
+    RF_MEDION_PROTOCOL,
 #endif
-#if IRMP_SUPPORT_RF_HME_PROTOCOL == 1
-    RF_HME_PROTOCOL
+#if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
+    RF_HME_PROTOCOL,
+#endif
+#if IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
+    RF_AC104_PROTOCOL
 #endif
 };
 
@@ -512,10 +518,13 @@ const char * const irsnd_used_protocol_names[] PROGMEM =
     proto_rf_x10,
 #endif
 #if IRSND_SUPPORT_RF_MEDION_PROTOCOL == 1
-    proto_rf_medion
+    proto_rf_medion,
 #endif
 #if IRSND_SUPPORT_RF_HME_PROTOCOL == 1
     proto_rf_hme
+#endif
+#if IRSND_SUPPORT_RF_AC104_PROTOCOL == 1
+    proto_rf_ac104
 #endif
 };
 

--- a/src/irsndArduinoExt.h
+++ b/src/irsndArduinoExt.h
@@ -54,6 +54,9 @@ void irsnd_init(uint_fast8_t aIrsndOutputPin, uint_fast8_t aFeedbackLedPin, bool
 #  if !defined(IRSND_OUTPUT_PIN)                // Arduino IDE uses IRSND_OUTPUT_PIN instead of PORT and BIT
 #define IRSND_OUTPUT_PIN            4
 #  endif
+#  if defined(IRSND_RF_OUTPUT) && !defined(IRSEND_RF_PIN)
+#define IRSND_RF_PIN                12
+#  endif
 #endif // defined(IRMP_IRSND_ALLOW_DYNAMIC_PINS)
 
 void irsnd_data_print(Print *aSerial, IRMP_DATA *aIRMPDataPtr);


### PR DESCRIPTION
Implementation of further protocols:
'HomeEasy' advanced protocol for simple RF controlled switches
Information can be found here: https://homeeasyhacking.fandom.com/wiki/Advanced_Protocol
I did not implement the described dimming function, as I did not need it and as it is a bit 'hacky' 
The repartition of address and command just made so that the upper bits 16 bits are in the address and the lower 16 bits in the command.   This is a bit arbitrary according to the specs from the page above.  To swicht a device on or of, bit at 0x0010 needs to be toggled in the command word.

AC104 protocol for some projector screens or similar:
Information can be found here: https://github.com/akirjavainen/A-OK/issues/1
I found however, that I needed to tweak the timing a bit, especially the pause between the repeats needed to be very short for the sending to work.
There needs to be a 24 bit ID being sent.   This is implemented as follows:
A macro  `RF_AC104_ID  0x123456`
has to be defined.   If the received ID matches the macro definition, address and command are stored accordingly.  Otherwise the upper 16 bit of the ID are stored in the address and the lower 8 bit in the command.

General implementation of sending RF (for Arduino only):
A flag irsnd_rf is handled in irsnd.c.h.  It is set to 1 if a supported RF protocol is chosen and reset after done with sending.
the macro `IRSND_RF_PIN` is defined in irsndArduinoExt.h and defaults to Pin 12.
It can be overwritten before including irsnd.c.h
I implemented the above two protocol and RF_GEN24.  For the latter, I also found that I needed to tweak the time constants for my hardware to work.  Feel free to change it to the original values if you choose to take in this pull request.   It may be very particular to my hardware (again, a set of RF-controlled sockets).



